### PR TITLE
Use Composer when updating our tracker installations

### DIFF
--- a/update-trackers.sh
+++ b/update-trackers.sh
@@ -160,9 +160,9 @@ do
 		continue
 	fi
 
-	# Update submodules
-	echo "- Updating submodules"
-	git submodule update --init --recursive
+	# Update Composer packages
+	echo "- Installing / Updating composer packages"
+	composer install
 
 	# Updating the version suffix in config file
 	echo "- Setting version_suffix to '$VERSION_SUFFIX' in $CONFIG_FILE"


### PR DESCRIPTION
We don't use git submodules any longer since some while.
Use Composer instead of it.

Fixes #24991